### PR TITLE
Store market option color in database

### DIFF
--- a/apps/web/app/(app)/questions/page.tsx
+++ b/apps/web/app/(app)/questions/page.tsx
@@ -32,18 +32,10 @@ export default async function AppQuestionsPage() {
     return {
       ...market,
       user: sanitizeUser(market.user),
-      options: market.options.map((option) => ({
-        ...option,
-        color: option.color,
-      })),
       marketResolution: market.marketResolution
         ? {
             ...market.marketResolution,
             resolvedBy: sanitizeUser(market.marketResolution.resolvedBy),
-            resolution: {
-              ...market.marketResolution.resolution,
-              color: market.marketResolution.resolution.color,
-            },
           }
         : undefined,
     }

--- a/apps/web/app/(app)/questions/page.tsx
+++ b/apps/web/app/(app)/questions/page.tsx
@@ -34,7 +34,7 @@ export default async function AppQuestionsPage() {
       user: sanitizeUser(market.user),
       options: market.options.map((option) => ({
         ...option,
-        color: option.currencyCode === 'YES' ? '#3b82f6' : '#ec4899',
+        color: option.color,
       })),
       marketResolution: market.marketResolution
         ? {
@@ -42,7 +42,7 @@ export default async function AppQuestionsPage() {
             resolvedBy: sanitizeUser(market.marketResolution.resolvedBy),
             resolution: {
               ...market.marketResolution.resolution,
-              color: market.marketResolution.resolution.currencyCode === 'YES' ? '#3b82f6' : '#ec4899',
+              color: market.marketResolution.resolution.color,
             },
           }
         : undefined,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:push": "dotenv -- turbo db:push",
     "db:generate": "dotenv -- turbo db:generate",
     "db:script": "dotenv -- npm run script -w @play-money/database",
+    "db:reset": "dotenv -- turbo db:reset",
     "test": "turbo run test",
     "test:watch": "turbo run test:watch"
   },

--- a/packages/database/migrations/20240710023422_add_option_color/migration.sql
+++ b/packages/database/migrations/20240710023422_add_option_color/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "MarketOption" ADD COLUMN     "color" TEXT NOT NULL DEFAULT '#FF00FF';
+
+UPDATE "MarketOption" SET "color" = '#3B82F6' WHERE "currencyCode" = 'YES';
+UPDATE "MarketOption" SET "color" = '#EC4899' WHERE "currencyCode" = 'NO';

--- a/packages/database/mocks.ts
+++ b/packages/database/mocks.ts
@@ -127,6 +127,7 @@ export function mockMarketOption(overrides?: Partial<MarketOption>): MarketOptio
     id: faker.string.uuid(),
     name: currencyCode === 'YES' ? 'Yes' : 'No',
     currencyCode,
+    color: currencyCode === 'YES' ? '#3B82F6' : '#EC4899',
     marketId: faker.string.uuid(),
     createdAt: faker.date.past(),
     updatedAt: faker.date.past(),

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "db:generate": "prisma generate && prisma format",
     "db:push": "prisma db push --skip-generate",
+    "db:reset": "prisma migrate reset --force",
     "dev": "cross-env BROWSER=none prisma studio",
     "type-check": "tsc --noEmit",
     "script": "tsx scripts/run.js"

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -107,6 +107,7 @@ model MarketOption {
   market       Market             @relation(fields: [marketId], references: [id])
   currencyCode CurrencyCode
   currency     Currency           @relation(fields: [currencyCode], references: [code])
+  color        String             @default("#FF00FF") /// @zod.string.regex(/^#[0-9A-Fa-f]{6}$/)
   resolutions  MarketResolution[]
   createdAt    DateTime           @default(now())
   updatedAt    DateTime           @updatedAt

--- a/packages/database/zod/inputTypeSchemas/MarketOptionScalarFieldEnumSchema.ts
+++ b/packages/database/zod/inputTypeSchemas/MarketOptionScalarFieldEnumSchema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
 
-export const MarketOptionScalarFieldEnumSchema = z.enum(['id','name','marketId','currencyCode','createdAt','updatedAt']);
+export const MarketOptionScalarFieldEnumSchema = z.enum(['id','name','marketId','currencyCode','color','createdAt','updatedAt']);
 
 export default MarketOptionScalarFieldEnumSchema;

--- a/packages/database/zod/modelSchema/MarketOptionSchema.ts
+++ b/packages/database/zod/modelSchema/MarketOptionSchema.ts
@@ -10,6 +10,7 @@ export const MarketOptionSchema = z.object({
   id: z.string().cuid(),
   name: z.string(),
   marketId: z.string(),
+  color: z.string().regex(/^#[0-9A-Fa-f]{6}$/),
   createdAt: z.coerce.date(),
   updatedAt: z.coerce.date(),
 })

--- a/packages/markets/lib/createMarket.ts
+++ b/packages/markets/lib/createMarket.ts
@@ -70,6 +70,7 @@ export async function createMarket({
           data: parsedOptions.map((option) => ({
             name: option.name,
             currencyCode: option.currencyCode,
+            color: option.currencyCode === 'YES' ? '#3B82F6' : '#EC4899',
             updatedAt: new Date(),
             createdAt: new Date(),
           })),

--- a/packages/markets/lib/getMarket.ts
+++ b/packages/markets/lib/getMarket.ts
@@ -33,18 +33,10 @@ export async function getMarket({
     return {
       ...market,
       user: sanitizeUser(market.user),
-      options: market.options.map((option) => ({
-        ...option,
-        color: option.color
-      })),
       marketResolution: market.marketResolution
         ? {
             ...market.marketResolution,
             resolvedBy: sanitizeUser(market.marketResolution.resolvedBy),
-            resolution: {
-              ...market.marketResolution.resolution,
-              color: market.marketResolution.resolution.color,
-            },
           }
         : undefined,
     }

--- a/packages/markets/lib/getMarket.ts
+++ b/packages/markets/lib/getMarket.ts
@@ -35,7 +35,7 @@ export async function getMarket({
       user: sanitizeUser(market.user),
       options: market.options.map((option) => ({
         ...option,
-        color: option.currencyCode === 'YES' ? '#3b82f6' : '#ec4899',
+        color: option.color
       })),
       marketResolution: market.marketResolution
         ? {
@@ -43,7 +43,7 @@ export async function getMarket({
             resolvedBy: sanitizeUser(market.marketResolution.resolvedBy),
             resolution: {
               ...market.marketResolution.resolution,
-              color: market.marketResolution.resolution.currencyCode === 'YES' ? '#3b82f6' : '#ec4899',
+              color: market.marketResolution.resolution.color,
             },
           }
         : undefined,

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,9 @@
     "db:push": {
       "cache": false
     },
+    "db:reset": {
+      "cache": false
+    },
     "test": {},
     "test:watch": {
       "cache": false


### PR DESCRIPTION
A first pass at adding the colors to the database schema. Only works on binary options, and is hard coded to two values.

In the future, this could be extended to handle more colors and customization.

This is my first time doing a non-trivial database migration in prisma, so let me know if I missed anything.