### PR TITLE
Update currency symbol

### DIFF
--- a/packages/markets/components/MarketBuyForm.tsx
+++ b/packages/markets/components/MarketBuyForm.tsx
@@ -172,7 +172,7 @@ export function MarketBuyForm({
 }
 
 // TODO: Create format components and using existing currency component
-export const formatCurrency = (value: number) => `$${Math.round(value)}`
+export const formatCurrency = (value: number) => `¤${Math.round(value)}`
 
 export const formatPercentage = (value: number) => `${Math.round(value * 100)}%`
 


### PR DESCRIPTION
We're using the universal currency symbol now, but a single $ was still remaining.