### PR TITLE
Fix market not being found when the slug is empty

### DIFF
--- a/packages/markets/lib/helpers.ts
+++ b/packages/markets/lib/helpers.ts
@@ -15,7 +15,7 @@ export function slugifyTitle(title: string, maxLen = 50) {
     slug = slug.substring(0, maxLen).replace(/-+[^-]*?$/, '') // Remove the last word, since it might be cut off
   }
 
-  return slug
+  return slug || 'market'
 }
 
 const chrono = baseChrono.casual.clone()


### PR DESCRIPTION
When you create a question with non-latin characters the slug may end up being empty. This leads to 404 errors on questions. I ran into this issue when trying to create questions in Russian which uses Cyrillic script.

I'm not sure this is the best way to fix it, but I figured I'd submit a PR so at least you folks are aware of the issues.

